### PR TITLE
fix(bedrock): 既定チャットモデルIDを東京 in-region 向けに変更 (#34)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,13 @@ SLACK_APP_TOKEN=
 # AWS_DEFAULT_REGION=ap-northeast-1
 # 未設定かつ USE_BEDROCK=true のとき既定: anthropic.claude-3-5-haiku-20241022-v1:0（in-region 向け）
 # BEDROCK_CHAT_MODEL_ID=anthropic.claude-3-5-haiku-20241022-v1:0
-# 東京で Sonnet 4.6 を geo 推論で使う例（AWS モデルカードの inference profile ID）:
+# 東京で Sonnet 4.6 を geo 推論で使う例（AWS モデルカードの inference profile ID）。
+# 注意: jp.* プロファイルは IAM に aws-marketplace:ViewSubscriptions / Subscribe が無いと
+# AccessDenied になることがある。回避は in-region モデル（上の Haiku 等）か Marketplace 権限付与。
+# 詳細: docs/20260514-bedrock-marketplace-access.md
 # BEDROCK_CHAT_MODEL_ID=jp.anthropic.claude-sonnet-4-6
+# Converse を使わず最初から InvokeModel のみ（Converse 権限が無い環境向け）
+# BEDROCK_CHAT_SKIP_CONVERSE=false
 # （参考・現状の埋め込みは Bedrock では使わない）Titan 用の旧変数:
 # BEDROCK_EMBEDDING_MODEL_ID=amazon.titan-embed-text-v2:0
 # BEDROCK_EMBEDDING_DIMENSIONS=1024

--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,10 @@ SLACK_APP_TOKEN=
 # --- Amazon Bedrock（例: 東京・チャットのみ）---
 # AWS_REGION=ap-northeast-1
 # AWS_DEFAULT_REGION=ap-northeast-1
-# BEDROCK_CHAT_MODEL_ID=anthropic.claude-sonnet-4-6
+# 未設定かつ USE_BEDROCK=true のとき既定: anthropic.claude-3-5-haiku-20241022-v1:0（in-region 向け）
+# BEDROCK_CHAT_MODEL_ID=anthropic.claude-3-5-haiku-20241022-v1:0
+# 東京で Sonnet 4.6 を geo 推論で使う例（AWS モデルカードの inference profile ID）:
+# BEDROCK_CHAT_MODEL_ID=jp.anthropic.claude-sonnet-4-6
 # （参考・現状の埋め込みは Bedrock では使わない）Titan 用の旧変数:
 # BEDROCK_EMBEDDING_MODEL_ID=amazon.titan-embed-text-v2:0
 # BEDROCK_EMBEDDING_DIMENSIONS=1024

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ OpenAI 互換 API からの移行手順・ベクトル次元の注意は [docs/2
    **RAG・ingest・Web 要約（Bedrock または OpenAI 互換）**
 
    - **バックエンドの優先**: `USE_BEDROCK=true`、または `BEDROCK_CHAT_MODEL_ID` を設定するとチャットは Bedrock。`USE_BEDROCK=false` で OpenAI 互換のみに固定。
-   - **Bedrock（チャット）時**: AWS 認証、`AWS_REGION` または `AWS_DEFAULT_REGION`（既定 `ap-northeast-1`）、`BEDROCK_CHAT_MODEL_ID`。IAM の例: `bedrock:InvokeModel`、Converse 利用時は `bedrock:Converse`。**加えて埋め込み用に `AI_API_KEY`（および任意で `AI_BASE_URL`・`AI_EMBEDDING_MODEL`）が必須。**
+   - **Bedrock（チャット）時**: AWS 認証、`AWS_REGION` または `AWS_DEFAULT_REGION`（既定 `ap-northeast-1`）、`BEDROCK_CHAT_MODEL_ID`（未設定時の既定は `anthropic.claude-3-5-haiku-20241022-v1:0`）。IAM の例: `bedrock:InvokeModel`、Converse 利用時は `bedrock:Converse`。**加えて埋め込み用に `AI_API_KEY`（および任意で `AI_BASE_URL`・`AI_EMBEDDING_MODEL`）が必須。** 東京リージョンで Claude Sonnet 4.6 など **geo 推論**のみの場合は、AWS のモデルカードに従い `BEDROCK_CHAT_MODEL_ID=jp.anthropic.claude-sonnet-4-6` のように **jp. 付き inference profile ID** を指定する（詳細は [docs/20260514-bedrock-chat-model-invalid.md](docs/20260514-bedrock-chat-model-invalid.md)）。
    - **OpenAI 互換のみ（Bedrock 未使用）**: `AI_API_KEY`、任意で `AI_BASE_URL`、`AI_CHAT_MODEL`（既定 `gpt-4o-mini`）、`AI_EMBEDDING_MODEL`（既定 `text-embedding-3-small`）
    - **埋め込み次元**: `AI_EMBEDDING_MODEL` を変えたら Chroma / pgvector の次元と一致させる。**モデルを変えたら `ingest` を再実行**すること。
 
@@ -89,7 +89,8 @@ OpenAI 互換 API からの移行手順・ベクトル次元の注意は [docs/2
    AWS_REGION=ap-northeast-1
    AWS_ACCESS_KEY_ID=...
    AWS_SECRET_ACCESS_KEY=...
-   BEDROCK_CHAT_MODEL_ID=anthropic.claude-sonnet-4-6
+   BEDROCK_CHAT_MODEL_ID=anthropic.claude-3-5-haiku-20241022-v1:0
+   # Sonnet 4.6 を東京で geo 推論する例: BEDROCK_CHAT_MODEL_ID=jp.anthropic.claude-sonnet-4-6
    AI_API_KEY=sk-...
    ```
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ OpenAI 互換 API からの移行手順・ベクトル次元の注意は [docs/2
    **RAG・ingest・Web 要約（Bedrock または OpenAI 互換）**
 
    - **バックエンドの優先**: `USE_BEDROCK=true`、または `BEDROCK_CHAT_MODEL_ID` を設定するとチャットは Bedrock。`USE_BEDROCK=false` で OpenAI 互換のみに固定。
-   - **Bedrock（チャット）時**: AWS 認証、`AWS_REGION` または `AWS_DEFAULT_REGION`（既定 `ap-northeast-1`）、`BEDROCK_CHAT_MODEL_ID`（未設定時の既定は `anthropic.claude-3-5-haiku-20241022-v1:0`）。IAM の例: `bedrock:InvokeModel`、Converse 利用時は `bedrock:Converse`。**加えて埋め込み用に `AI_API_KEY`（および任意で `AI_BASE_URL`・`AI_EMBEDDING_MODEL`）が必須。** 東京リージョンで Claude Sonnet 4.6 など **geo 推論**のみの場合は、AWS のモデルカードに従い `BEDROCK_CHAT_MODEL_ID=jp.anthropic.claude-sonnet-4-6` のように **jp. 付き inference profile ID** を指定する（詳細は [docs/20260514-bedrock-chat-model-invalid.md](docs/20260514-bedrock-chat-model-invalid.md)）。
+   - **Bedrock（チャット）時**: AWS 認証、`AWS_REGION` または `AWS_DEFAULT_REGION`（既定 `ap-northeast-1`）、`BEDROCK_CHAT_MODEL_ID`（未設定時の既定は `anthropic.claude-3-5-haiku-20241022-v1:0`）。IAM の例: `bedrock:InvokeModel`、Converse 利用時は `bedrock:Converse`。**加えて埋め込み用に `AI_API_KEY`（および任意で `AI_BASE_URL`・`AI_EMBEDDING_MODEL`）が必須。** 東京リージョンで Claude Sonnet 4.6 など **geo 推論**のみの場合は、AWS のモデルカードに従い `BEDROCK_CHAT_MODEL_ID=jp.anthropic.claude-sonnet-4-6` のように **jp. 付き inference profile ID** を指定できるが、この場合は **AWS Marketplace 向け IAM**（`ViewSubscriptions` / `Subscribe`）が追加で必要になることがある（詳細は [docs/20260514-bedrock-chat-model-invalid.md](docs/20260514-bedrock-chat-model-invalid.md)、[docs/20260514-bedrock-marketplace-access.md](docs/20260514-bedrock-marketplace-access.md)）。
    - **OpenAI 互換のみ（Bedrock 未使用）**: `AI_API_KEY`、任意で `AI_BASE_URL`、`AI_CHAT_MODEL`（既定 `gpt-4o-mini`）、`AI_EMBEDDING_MODEL`（既定 `text-embedding-3-small`）
    - **埋め込み次元**: `AI_EMBEDDING_MODEL` を変えたら Chroma / pgvector の次元と一致させる。**モデルを変えたら `ingest` を再実行**すること。
 
@@ -81,6 +81,7 @@ OpenAI 互換 API からの移行手順・ベクトル次元の注意は [docs/2
    - `RATE_LIMIT_PER_MINUTE` … Slack ユーザーあたりの RAG 呼び出し上限（既定 `20`）
    - `WEB_SEARCH_MAX_RESULTS` … Web 検索の最大件数（既定 `5`）
    - `CONTENT_FILTER_ENABLED` … コンテンツフィルターの有効/無効（既定 `true`。IT・プログラミング関連以外の質問をフィルタリング）
+   - `BEDROCK_CHAT_SKIP_CONVERSE` … `true` のときチャットは `InvokeModel` のみ（`Converse` を試さない。既定 `false`）
    - `SUPABASE_URL` / `SUPABASE_KEY` … Supabase 移行スクリプト利用時に必要（通常運用では任意）
 
    最小例（Bedrock チャット＋OpenAI 埋め込み。本番は IAM ロール推奨）:

--- a/docs/20260513-bedrock-openai-replacement.md
+++ b/docs/20260513-bedrock-openai-replacement.md
@@ -1,5 +1,7 @@
 # Bedrock と OpenAI 互換 API の使い分け（2026-05-13）
 
+`ValidationException: The provided model identifier is invalid` のときは [Bedrock チャット用モデル ID のトラブルシュート](./20260514-bedrock-chat-model-invalid.md) を参照。
+
 ## 意図
 
 チャットは **Amazon Bedrock** または **OpenAI 互換 API** を環境で切り替える。**埋め込み（ingest・RAG のクエリベクトル）は常に OpenAI 互換 API**（`openai` クライアント、`AI_API_KEY`）を使う。Bedrock でチャットする構成でも Titan 等の Bedrock 埋め込みは使わない。
@@ -13,7 +15,7 @@
 | 上記以外で `BEDROCK_CHAT_MODEL_ID` が非空 | Bedrock | OpenAI 互換 |
 | 上記以外 | OpenAI 互換 | OpenAI 互換 |
 
-`rag_enabled()` が True になるには、**常に `AI_API_KEY` が必要**。Bedrock 利用時はさらに AWS 認証が解決でき、`BEDROCK_CHAT_MODEL_ID`（または `USE_BEDROCK=true` 時の既定）が揃っていること。
+`rag_enabled()` が True になるには、**常に `AI_API_KEY` が必要**。Bedrock 利用時はさらに AWS 認証が解決でき、`BEDROCK_CHAT_MODEL_ID`（または `USE_BEDROCK=true` 時の既定 `anthropic.claude-3-5-haiku-20241022-v1:0`）が揃っていること。
 
 ## 環境変数（参照）
 

--- a/docs/20260513-bedrock-openai-replacement.md
+++ b/docs/20260513-bedrock-openai-replacement.md
@@ -1,6 +1,6 @@
 # Bedrock と OpenAI 互換 API の使い分け（2026-05-13）
 
-`ValidationException: The provided model identifier is invalid` のときは [Bedrock チャット用モデル ID のトラブルシュート](./20260514-bedrock-chat-model-invalid.md) を参照。
+`ValidationException: The provided model identifier is invalid` のときは [Bedrock チャット用モデル ID のトラブルシュート](./20260514-bedrock-chat-model-invalid.md) を参照。`AccessDeniedException` で `aws-marketplace:ViewSubscriptions` / `Subscribe` が出る場合は [Marketplace IAM と geo profile](./20260514-bedrock-marketplace-access.md) を参照。
 
 ## 意図
 
@@ -30,7 +30,7 @@
 ## 移行手順
 
 1. AWS 側でチャットモデルの **オンデマンドアクセス**（または利用可能な購入済みスループット）を有効化する。
-2. 実行主体に `bedrock:InvokeModel` および `bedrock:Converse`（利用する場合）を付与する。
+2. 実行主体に `bedrock:InvokeModel` および `bedrock:Converse`（利用する場合）を付与する。`jp.anthropic.*` など **geo inference profile** を使う場合は、追加で [Marketplace 向け IAM](./20260514-bedrock-marketplace-access.md) が必要になることがある。
 3. `.env` に [`.env.example`](../.env.example) に沿って AWS と `BEDROCK_CHAT_MODEL_ID` を設定し、**埋め込み用に `AI_API_KEY`** を設定する。
 4. **Chroma の再生成**: 旧 Titan（1024 次元）などと `AI_EMBEDDING_MODEL` の次元が異なる場合は `python3 scripts/ingest.py` を再実行する。
 5. **距離しきい値**: `RAG_MAX_DISTANCE` はベクトル空間に依存する。回答品質が変わったら調整する。

--- a/docs/20260514-bedrock-chat-model-invalid.md
+++ b/docs/20260514-bedrock-chat-model-invalid.md
@@ -28,6 +28,7 @@ Slack ボットで質問すると、`febot.content_filter` や `febot.slack_app`
 
 - **`AWS_REGION` / `AWS_DEFAULT_REGION`** が、利用するモデルが載っているリージョンと一致しているか。
 - Bedrock コンソールで対象モデルの **アクセス（オンデマンド等）が有効**か。アクセス不足の場合は別メッセージ（例: `AccessDeniedException`）になりやすいが、運用で混同しないようコンソールも確認する。
+- `jp.*` プロファイル利用時に `aws-marketplace:ViewSubscriptions` がログに出る場合は、モデル ID ではなく **IAM（Marketplace）** の問題。[Marketplace と AccessDenied](./20260514-bedrock-marketplace-access.md) を参照。
 - `.env` の値に **余計な引用符**が含まれていないか（実装では先頭末尾の `'` / `"` を1重だけ除去する）。
 
 ## 関連ドキュメント

--- a/docs/20260514-bedrock-chat-model-invalid.md
+++ b/docs/20260514-bedrock-chat-model-invalid.md
@@ -1,0 +1,35 @@
+# Bedrock `The provided model identifier is invalid`（2026-05-14）
+
+## 症状
+
+Slack ボットで質問すると、`febot.content_filter` や `febot.slack_app`（RAG）経由の Bedrock 呼び出しで次のようなログが出る。
+
+- `Bedrock Converse failed (ValidationException), trying InvokeModel`
+- `ValidationException: The provided model identifier is invalid`（`Converse` / `InvokeModel` の両方）
+
+埋め込み（OpenAI）や Supabase は HTTP 200 のまま、**チャット用 Bedrock の `modelId` のみ**が失敗している状態。
+
+## 原因（コード上の流れ）
+
+1. [`src/febot/config.py`](../src/febot/config.py) の `Settings.load()` が `BEDROCK_CHAT_MODEL_ID`（正規化後）を解決し、空なら **既定の in-region モデル ID** を使う。
+2. [`src/febot/bedrock_client.py`](../src/febot/bedrock_client.py) が `converse` / `invoke_model` の **`modelId`** にその文字列をそのまま渡す。
+
+リージョン・アカウント・モデル提供形態によっては、**foundation model の短い ID**（例: `anthropic.claude-sonnet-4-6`）がそのリージョンのランタイムでは受け付けられず、上記の `ValidationException` になることがある。
+
+## 対処
+
+| 目的 | 設定例 |
+|------|--------|
+| まず動かす（コスト重視・東京 in-region 向け既定） | `BEDROCK_CHAT_MODEL_ID` を空のまま `USE_BEDROCK=true` にするか、明示で `anthropic.claude-3-5-haiku-20241022-v1:0` |
+| 品質寄りの in-region | `anthropic.claude-3-5-sonnet-20240620-v1:0` |
+| 東京で Sonnet 4.6 を **geo inference profile** で使う | AWS のモデルカードに従い `jp.anthropic.claude-sonnet-4-6` を `BEDROCK_CHAT_MODEL_ID` に指定 |
+
+併せて確認する項目:
+
+- **`AWS_REGION` / `AWS_DEFAULT_REGION`** が、利用するモデルが載っているリージョンと一致しているか。
+- Bedrock コンソールで対象モデルの **アクセス（オンデマンド等）が有効**か。アクセス不足の場合は別メッセージ（例: `AccessDeniedException`）になりやすいが、運用で混同しないようコンソールも確認する。
+- `.env` の値に **余計な引用符**が含まれていないか（実装では先頭末尾の `'` / `"` を1重だけ除去する）。
+
+## 関連ドキュメント
+
+- [Bedrock と OpenAI 互換の使い分け](./20260513-bedrock-openai-replacement.md)

--- a/docs/20260514-bedrock-marketplace-access.md
+++ b/docs/20260514-bedrock-marketplace-access.md
@@ -1,0 +1,52 @@
+# Bedrock `jp.*` モデルと AWS Marketplace / IAM
+
+## 症状
+
+`BEDROCK_CHAT_MODEL_ID=jp.anthropic.claude-sonnet-4-6` のように **リージョン推論プロファイル（`jp.` プレフィックス）** を指定したとき、Bedrock Runtime の `Converse` または `InvokeModel` が次のように失敗することがある。
+
+- `AccessDeniedException`
+- メッセージに `aws-marketplace:ViewSubscriptions` / `Subscribe` / `AWS Marketplace` が含まれる
+
+埋め込み（OpenAI 互換 API）は成功し、チャットだけ失敗する、という切り分けになりやすい。
+
+## 原因
+
+`jp.*` のような **geo / inference profile** 利用は、モデル提供形態の都合で **AWS Marketplace 側の購読・権限チェック** が挟まることがある。  
+その場合、IAM に `bedrock:InvokeModel` だけを付けても不十分で、エラーに示されるとおり **Marketplace 向けアクション** と **コンソール上の利用有効化** が必要になる。
+
+（逆に、リージョン内の通常モデル ID、例: `anthropic.claude-3-5-haiku-20241022-v1:0` は、Bedrock コンソールの「モデルアクセス」で許可されていれば Marketplace 文言なく動くことが多い。）
+
+## 対処（どちらか）
+
+### A. IAM と Marketplace で `jp.*` を使い続ける
+
+1. IAM ロール（例: `febot-ec2-role`）に、エラーに書かれている Marketplace アクションを付与する（組織方針に従い最小権限で）。
+2. AWS Marketplace / Bedrock コンソールで、対象モデル・推論プロファイルの **利用契約・購読** を完了する。
+3. 変更反映後、数分待って再試行する（エラー文面の案内どおり）。
+
+### B. Marketplace を避ける（推奨: まず動かすならこちら）
+
+`.env` の `BEDROCK_CHAT_MODEL_ID` を **in-region のオンデマンドモデル ID** に変える。
+
+例（東京 `ap-northeast-1` でよく使う既定）:
+
+```bash
+BEDROCK_CHAT_MODEL_ID=anthropic.claude-3-5-haiku-20241022-v1:0
+```
+
+Bedrock コンソールで当該モデルのアクセスが有効になっていること。
+
+## 実装側の補助（本リポジトリ）
+
+- `bedrock_client`: `Converse` が `AccessDeniedException` のとき **`InvokeModel` にフォールバック**する。  
+  Marketplace 起因の拒否では **両方同じ理由で失敗しうる** が、`bedrock:Converse` のみ不足している環境では Invoke で通る場合がある。
+- 任意: `BEDROCK_CHAT_SKIP_CONVERSE=true` で最初から `InvokeModel` のみ使う（ログを簡素化したいとき）。
+- `slack_app` / `content_filter`: Marketplace 型の拒否を検知し、Slack では説明付きメッセージ、フィルターは **fail-open**（チャット不能で学習ボットが止まらないように）。
+
+## 具体例
+
+- **設定**: `AWS_REGION=ap-northeast-1`, `BEDROCK_CHAT_MODEL_ID=jp.anthropic.claude-sonnet-4-6`
+- **IAM**: `bedrock:InvokeModel` のみ
+- **結果**: `AccessDeniedException` + Marketplace 文言 → **A か B のどちらかが必要**
+
+`BEDROCK_CHAT_MODEL_ID` を `anthropic.claude-3-5-haiku-20241022-v1:0` に変え、コンソールで Haiku を有効化すると、同じ IAM でもチャットが通る例が多い。

--- a/src/febot/bedrock_client.py
+++ b/src/febot/bedrock_client.py
@@ -68,7 +68,9 @@ class BedrockClient:
     ) -> str:
         """Run Claude on Bedrock; prefer Converse, fall back to InvokeModel."""
         try:
-            return self._chat_via_converse(system, user, temperature=temperature, max_tokens=max_tokens)
+            return self._chat_via_converse(
+                system, user, temperature=temperature, max_tokens=max_tokens
+            )
         except ClientError as e:
             err_code = e.response.get("Error", {}).get("Code", "")
             if err_code == "AccessDeniedException":

--- a/src/febot/bedrock_client.py
+++ b/src/febot/bedrock_client.py
@@ -29,6 +29,11 @@ class BedrockClient:
 
     def embed_texts(self, texts: list[str]) -> list[list[float]]:
         """Titan Text Embeddings V2: one InvokeModel call per input string."""
+        log.info(
+            "使用AI embed: provider=bedrock model_id=%s texts=%d",
+            self._embed_model_id,
+            len(texts),
+        )
         out: list[list[float]] = []
         for t in texts:
             body = json.dumps(
@@ -68,6 +73,7 @@ class BedrockClient:
         max_tokens: int | None,
     ) -> str:
         """Run Claude on Bedrock; prefer Converse, fall back to InvokeModel."""
+        log.info("使用AI chat: provider=bedrock model_id=%s", self._chat_model_id)
         if self._skip_converse:
             return self._chat_via_invoke(
                 system, user, temperature=temperature, max_tokens=max_tokens

--- a/src/febot/bedrock_client.py
+++ b/src/febot/bedrock_client.py
@@ -85,9 +85,7 @@ class BedrockClient:
         except ClientError as e:
             err_code = e.response.get("Error", {}).get("Code", "")
             if err_code == "AccessDeniedException":
-                log.warning(
-                    "Bedrock Converse AccessDenied, trying InvokeModel (same model): %s", e
-                )
+                log.warning("Bedrock Converse AccessDenied, trying InvokeModel (same model): %s", e)
                 return self._chat_via_invoke(
                     system, user, temperature=temperature, max_tokens=max_tokens
                 )

--- a/src/febot/bedrock_client.py
+++ b/src/febot/bedrock_client.py
@@ -25,6 +25,7 @@ class BedrockClient:
         self._chat_model_id = settings.bedrock_chat_model_id
         self._embed_model_id = settings.bedrock_embedding_model_id
         self._embed_dimensions = settings.bedrock_embedding_dimensions
+        self._skip_converse = settings.bedrock_chat_skip_converse
 
     def embed_texts(self, texts: list[str]) -> list[list[float]]:
         """Titan Text Embeddings V2: one InvokeModel call per input string."""
@@ -67,6 +68,10 @@ class BedrockClient:
         max_tokens: int | None,
     ) -> str:
         """Run Claude on Bedrock; prefer Converse, fall back to InvokeModel."""
+        if self._skip_converse:
+            return self._chat_via_invoke(
+                system, user, temperature=temperature, max_tokens=max_tokens
+            )
         try:
             return self._chat_via_converse(
                 system, user, temperature=temperature, max_tokens=max_tokens
@@ -74,7 +79,12 @@ class BedrockClient:
         except ClientError as e:
             err_code = e.response.get("Error", {}).get("Code", "")
             if err_code == "AccessDeniedException":
-                raise
+                log.warning(
+                    "Bedrock Converse AccessDenied, trying InvokeModel (same model): %s", e
+                )
+                return self._chat_via_invoke(
+                    system, user, temperature=temperature, max_tokens=max_tokens
+                )
             log.warning("Bedrock Converse failed (%s), trying InvokeModel: %s", err_code, e)
         except Exception as e:
             log.warning("Bedrock Converse failed, trying InvokeModel: %s", e)

--- a/src/febot/bedrock_errors.py
+++ b/src/febot/bedrock_errors.py
@@ -1,0 +1,43 @@
+"""Bedrock / IAM errors surfaced to Slack and content-filter fail-open."""
+
+from __future__ import annotations
+
+from botocore.exceptions import ClientError
+
+
+def is_marketplace_access_denied(exc: BaseException) -> bool:
+    """True when Bedrock denies access because AWS Marketplace actions are missing."""
+    code, msg = _client_error_parts(exc)
+    if code != "AccessDeniedException":
+        return False
+    lower = msg.lower()
+    return "marketplace" in lower or "viewsubscriptions" in lower.replace(" ", "")
+
+
+def slack_reply_for_bedrock_access_error(exc: BaseException) -> str | None:
+    """Slack 向け短文。該当しない場合は None（汎用エラー文言にフォールバック）。"""
+    if is_marketplace_access_denied(exc):
+        return (
+            "Bedrock のチャットモデルへのアクセスが拒否されました（*AWS Marketplace* 関連）。\n"
+            "次のいずれかで対応してください。\n"
+            "• IAM に `aws-marketplace:ViewSubscriptions`（必要なら `aws-marketplace:Subscribe`）を付与し、"
+            "該当モデル／推論プロファイルの利用を有効化する\n"
+            "• `BEDROCK_CHAT_MODEL_ID` を Marketplace 不要な in-region モデルに変更する（例: "
+            "`anthropic.claude-3-5-haiku-20241022-v1:0`）\n"
+            "詳細: README の Bedrock 節、`docs/20260514-bedrock-marketplace-access.md`。"
+        )
+    code, msg = _client_error_parts(exc)
+    if code == "AccessDeniedException":
+        return (
+            "Bedrock へのアクセスが拒否されました（AccessDenied）。\n"
+            "IAM の `bedrock:InvokeModel` / `bedrock:Converse`（利用している API に合わせる）と、"
+            "Bedrock コンソールのモデルアクセス設定を確認してください。"
+        )
+    return None
+
+
+def _client_error_parts(exc: BaseException) -> tuple[str, str]:
+    if isinstance(exc, ClientError):
+        err = exc.response.get("Error") or {}
+        return str(err.get("Code") or ""), str(err.get("Message") or "")
+    return "", str(exc)

--- a/src/febot/config.py
+++ b/src/febot/config.py
@@ -24,6 +24,14 @@ def _aws_credentials_available() -> bool:
         return False
 
 
+def _strip_bedrock_chat_model_id(raw: str) -> str:
+    """Strip whitespace and a single matching pair of outer ' or \" from .env values."""
+    s = raw.strip()
+    if len(s) >= 2 and s[0] in "\"'" and s[0] == s[-1]:
+        return s[1:-1].strip()
+    return s
+
+
 def _should_use_bedrock() -> bool:
     """True if USE_BEDROCK is enabled, or BEDROCK_CHAT_MODEL_ID is set (chat on Bedrock; embed uses OpenAI API)."""
     raw = os.environ.get("USE_BEDROCK", "").strip().lower()
@@ -31,7 +39,7 @@ def _should_use_bedrock() -> bool:
         return False
     if raw in ("1", "true", "yes"):
         return True
-    chat = os.environ.get("BEDROCK_CHAT_MODEL_ID", "").strip()
+    chat = _strip_bedrock_chat_model_id(os.environ.get("BEDROCK_CHAT_MODEL_ID", ""))
     return bool(chat)
 
 
@@ -76,9 +84,10 @@ class Settings:
             or os.environ.get("AWS_DEFAULT_REGION", "").strip()
             or "ap-northeast-1"
         )
+        # In-region default for ap-northeast-1; Sonnet 4.x may need geo IDs (e.g. jp.*) — see README / docs.
         chat_model = (
-            os.environ.get("BEDROCK_CHAT_MODEL_ID", "").strip()
-            or "anthropic.claude-sonnet-4-6"
+            _strip_bedrock_chat_model_id(os.environ.get("BEDROCK_CHAT_MODEL_ID", ""))
+            or "anthropic.claude-3-5-haiku-20241022-v1:0"
         )
         embed_model = (
             os.environ.get("BEDROCK_EMBEDDING_MODEL_ID", "").strip()

--- a/src/febot/config.py
+++ b/src/febot/config.py
@@ -52,6 +52,7 @@ class Settings:
     bedrock_chat_model_id: str
     bedrock_embedding_model_id: str
     bedrock_embedding_dimensions: int
+    bedrock_chat_skip_converse: bool
     ai_api_key: str
     ai_base_url: str | None
     ai_chat_model: str
@@ -111,6 +112,10 @@ class Settings:
             "CONTENT_FILTER_ENABLED", "true"
         ).strip().lower() in ("true", "1", "yes")
 
+        bedrock_chat_skip_converse = os.environ.get(
+            "BEDROCK_CHAT_SKIP_CONVERSE", ""
+        ).strip().lower() in ("true", "1", "yes")
+
         return Settings(
             slack_token=slack_token,
             slack_app_token=slack_app_token,
@@ -119,6 +124,7 @@ class Settings:
             bedrock_chat_model_id=chat_model,
             bedrock_embedding_model_id=embed_model,
             bedrock_embedding_dimensions=embed_dims,
+            bedrock_chat_skip_converse=bedrock_chat_skip_converse,
             ai_api_key=ai_key,
             ai_base_url=base,
             ai_chat_model=ai_chat,

--- a/src/febot/content_filter.py
+++ b/src/febot/content_filter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
+from febot.bedrock_errors import is_marketplace_access_denied
 from febot.config import Settings
 from febot.llm_backend import get_llm_backend
 
@@ -89,7 +90,13 @@ class ContentFilter:
                 )
 
         except Exception as e:
-            logger.error(f"Content filter error: {e}", exc_info=True)
+            if is_marketplace_access_denied(e):
+                logger.warning(
+                    "Content filter: Bedrock unavailable (Marketplace IAM on chat model). fail-open: %s",
+                    e,
+                )
+            else:
+                logger.error("Content filter error: %s", e, exc_info=True)
             # Fail open: allow the question if filter fails
             return FilterResult(
                 is_valid=True,

--- a/src/febot/llm_backend.py
+++ b/src/febot/llm_backend.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Protocol
 
 from openai import OpenAI
 
 from febot.bedrock_client import BedrockClient
 from febot.config import Settings
+
+log = logging.getLogger(__name__)
 
 
 class ChatEmbedBackend(Protocol):
@@ -49,10 +52,20 @@ class OpenAICompatBackend:
         }
         if max_tokens is not None:
             kwargs["max_tokens"] = max_tokens
+        log.info(
+            "使用AI chat: provider=openai-compatible model=%s base_url=%s",
+            self._chat_model,
+            str(self._client.base_url).rstrip("/"),
+        )
         response = self._client.chat.completions.create(**kwargs)
         return (response.choices[0].message.content or "").strip()
 
     def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        log.info(
+            "使用AI embed: provider=openai-compatible model=%s texts=%d",
+            self._embed_model,
+            len(texts),
+        )
         resp = self._client.embeddings.create(model=self._embed_model, input=texts)
         return [e.embedding for e in sorted(resp.data, key=lambda x: x.index)]
 

--- a/src/febot/slack_app.py
+++ b/src/febot/slack_app.py
@@ -13,6 +13,7 @@ from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 
 from febot import web_search as ws
+from febot.bedrock_errors import slack_reply_for_bedrock_access_error
 from febot.config import Settings
 from febot.content_filter import ContentFilter
 from febot.quiz import QuizItem, load_quiz_items, normalize_answer, pick_random
@@ -103,7 +104,11 @@ def _handle_rag_question(
         out = rag.answer(user_id, text)
     except Exception as e:
         log.exception("rag failed: %s", e)
-        say("処理中にエラーが発生しました。管理者に連絡してください。", **kwargs)
+        msg = slack_reply_for_bedrock_access_error(e)
+        say(
+            msg or "処理中にエラーが発生しました。管理者に連絡してください。",
+            **kwargs,
+        )
         return
 
     if out is not None:

--- a/tests/test_bedrock_errors.py
+++ b/tests/test_bedrock_errors.py
@@ -1,0 +1,64 @@
+"""Unit tests for Bedrock IAM / Marketplace error helpers."""
+
+from __future__ import annotations
+
+import pytest
+from botocore.exceptions import ClientError
+
+from febot.bedrock_errors import (
+    is_marketplace_access_denied,
+    slack_reply_for_bedrock_access_error,
+)
+
+
+def _access_denied(message: str) -> ClientError:
+    return ClientError(
+        {"Error": {"Code": "AccessDeniedException", "Message": message}},
+        "Converse",
+    )
+
+
+def test_marketplace_denied_detected() -> None:
+    exc = _access_denied(
+        "Model access is denied due to IAM user or service role is not authorized "
+        "to perform the required AWS Marketplace actions (aws-marketplace:ViewSubscriptions)"
+    )
+    assert is_marketplace_access_denied(exc) is True
+    reply = slack_reply_for_bedrock_access_error(exc)
+    assert reply is not None
+    assert "Marketplace" in reply
+    assert "BEDROCK_CHAT_MODEL_ID" in reply
+
+
+def test_marketplace_denied_message_variant() -> None:
+    exc = _access_denied("Your AWS Marketplace subscription for this model cannot be completed")
+    assert is_marketplace_access_denied(exc) is True
+
+
+def test_non_marketplace_access_denied() -> None:
+    exc = _access_denied("User is not authorized to perform: bedrock:InvokeModel")
+    assert is_marketplace_access_denied(exc) is False
+    reply = slack_reply_for_bedrock_access_error(exc)
+    assert reply is not None
+    assert "InvokeModel" in reply or "Bedrock" in reply
+
+
+def test_wrong_error_code() -> None:
+    exc = ClientError(
+        {"Error": {"Code": "ValidationException", "Message": "bad"}},
+        "Converse",
+    )
+    assert is_marketplace_access_denied(exc) is False
+    assert slack_reply_for_bedrock_access_error(exc) is None
+
+
+@pytest.mark.parametrize(
+    "msg",
+    [
+        "something failed",
+        "",
+    ],
+)
+def test_plain_exception_not_marketplace(msg: str) -> None:
+    assert is_marketplace_access_denied(RuntimeError(msg)) is False
+    assert slack_reply_for_bedrock_access_error(RuntimeError(msg)) is None


### PR DESCRIPTION
BEDROCK_CHAT_MODEL_ID 未設定時は Claude 3.5 Haiku を既定とし、.env の引用符を1重除去。README / .env.example に jp.* geo ID 案内を追加。ValidationException のトラブルシュートを docs に記載。bedrock_client からデバッグ用ファイル書き込みを除去。

# Pull Request Checklist

## Purpose

- Why is this change needed?

## Changes

- What changed in implementation?
- What changed in docs?

## Sync Checklist (Required)

- [ ] If implementation changed, related docs were updated in the same PR
- [ ] `README.md` is synchronized with behavior/setup changes
- [ ] `.env.example` is synchronized with env key changes
- [ ] Non-trivial changes are documented in `docs/[YYYYMMDD]-[title].md`
- [ ] No secrets (password/API key/token) are included in tracked files

## Verification

- How was this tested?
